### PR TITLE
Fix gcc-14,llvm-16 compile error on mpi.c

### DIFF
--- a/riscv.cfg
+++ b/riscv.cfg
@@ -171,7 +171,7 @@ default:   # data model applies to all benchmarks
    PORTABILITY   = -funsigned-char -DSPEC_LINUX
 
 527.cam4_r,627.cam4_s:  #lang='F,C'
-   CPORTABILITY  = -DSPEC_CASE_FLAG
+   CPORTABILITY  = -DSPEC_CASE_FLAG -Wno-error=implicit-int
    FPORTABILITY  = -fallow-argument-mismatch
 
 628.pop2_s:  #lang='F,C'


### PR DESCRIPTION
mpi.c:23:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]